### PR TITLE
fix: squash dark mode visual bugs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
     </a>
 </p>
 <p align="center">
-    <img src="https://github.com/alexieyizhe/intern.plus/workflows/continuous%20integration/badge.svg">
+    <img src="https://github.com/alexieyizhe/intern.plus/workflows/ci/badge.svg">
+    <img src="https://img.shields.io/github/v/tag/alexieyizhe/intern.plus?label=version">
 </p>
 
 ## ✨ Design

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import {
   EasterEggContextProvider,
   SiteThemeContextProvider,
 } from "src/contexts";
-import GlobalStyles from "src/theme/globalStyles";
+import GlobalStyles, { HeadingFontDefinition } from "src/theme/globalStyles";
 import { RouteName } from "src/shared/constants/routing";
 import Analytics, { analytics } from "src/shared/utils/analytics";
 
@@ -73,42 +73,45 @@ const App: React.FC = () => {
   }
 
   return (
-    <ApolloProvider client={apiClient}>
-      <SiteThemeContextProvider>
-        <AddReviewModalContextProvider>
-          <MobileMenuContextProvider>
-            <EasterEggContextProvider>
-              <Router>
-                <QueryParamProvider ReactRouterRoute={Route}>
-                  <ErrorBoundary FallbackComponent={CrashPage}>
-                    <div className="App">
-                      <GlobalStyles />
-                      {analytics.init() && <Analytics />}
+    <>
+      <HeadingFontDefinition />
+      <ApolloProvider client={apiClient}>
+        <SiteThemeContextProvider>
+          <AddReviewModalContextProvider>
+            <MobileMenuContextProvider>
+              <EasterEggContextProvider>
+                <Router>
+                  <QueryParamProvider ReactRouterRoute={Route}>
+                    <ErrorBoundary FallbackComponent={CrashPage}>
+                      <div className="App">
+                        <GlobalStyles />
+                        {analytics.init() && <Analytics />}
 
-                      <PageHeader />
-                      <Switch>
-                        <Route exact path={Object.values(RouteName)}>
-                          <AppRouteHandler />
-                        </Route>
+                        <PageHeader />
+                        <Switch>
+                          <Route exact path={Object.values(RouteName)}>
+                            <AppRouteHandler />
+                          </Route>
 
-                        {/* Render 404 if no other routes match */}
-                        <Route>
-                          <NotFoundPage />
-                        </Route>
-                      </Switch>
+                          {/* Render 404 if no other routes match */}
+                          <Route>
+                            <NotFoundPage />
+                          </Route>
+                        </Switch>
 
-                      <PageFooter />
+                        <PageFooter />
 
-                      <AddReviewModal />
-                    </div>
-                  </ErrorBoundary>
-                </QueryParamProvider>
-              </Router>
-            </EasterEggContextProvider>
-          </MobileMenuContextProvider>
-        </AddReviewModalContextProvider>
-      </SiteThemeContextProvider>
-    </ApolloProvider>
+                        <AddReviewModal />
+                      </div>
+                    </ErrorBoundary>
+                  </QueryParamProvider>
+                </Router>
+              </EasterEggContextProvider>
+            </MobileMenuContextProvider>
+          </AddReviewModalContextProvider>
+        </SiteThemeContextProvider>
+      </ApolloProvider>
+    </>
   );
 };
 

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -26,7 +26,7 @@ const BaseButton = styled(UnstyledButton)<IButtonProps>`
     theme.color[color] || color || "inherit"};
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
 
-  transition: all 100ms;
+  transition: all 150ms;
   border-radius: ${({ theme }) => theme.borderRadius.large}px;
   border: 2px solid transparent;
 

--- a/src/components/Card/CompanyCard/index.tsx
+++ b/src/components/Card/CompanyCard/index.tsx
@@ -72,7 +72,6 @@ const Container = styled(Card)`
       "desc    logo"
       "ratings logo";
 
-    color: inherit;
     text-decoration: none;
 
     & > .name {

--- a/src/components/Card/CompanyCard/index.tsx
+++ b/src/components/Card/CompanyCard/index.tsx
@@ -131,7 +131,7 @@ const CompanyCard: React.FC<ICompanyCardProps> = ({
         <Text
           className="name"
           variant="heading2"
-          color={color && getPrimaryColor(isDark, color)}
+          color={getPrimaryColor(isDark, color)}
         >
           {name}
         </Text>

--- a/src/components/Card/JobCard/index.tsx
+++ b/src/components/Card/JobCard/index.tsx
@@ -149,7 +149,7 @@ const JobCard: React.FC<IJobCardProps> = ({
         <Text
           className="heading"
           variant="heading3"
-          color={color && getPrimaryColor(isDark, color)}
+          color={getPrimaryColor(isDark, color)}
         >
           {heading}
         </Text>

--- a/src/components/Card/JobCard/index.tsx
+++ b/src/components/Card/JobCard/index.tsx
@@ -84,7 +84,6 @@ const Container = styled(Card)`
       "salaryAmt   salaryAmt"
       "ratings     salaryInfo";
 
-    color: inherit;
     text-decoration: none;
 
     & > .heading {

--- a/src/components/Card/ReviewCard/index.tsx
+++ b/src/components/Card/ReviewCard/index.tsx
@@ -131,7 +131,7 @@ const ReviewCard: React.FC<IReviewCardProps> = ({
         <Text
           variant="heading3"
           className="heading"
-          color={color && getPrimaryColor(isDark, color)}
+          color={getPrimaryColor(isDark, color)}
         >
           {heading}
         </Text>

--- a/src/components/Card/ReviewCard/index.tsx
+++ b/src/components/Card/ReviewCard/index.tsx
@@ -43,7 +43,6 @@ const Container = styled(Card)`
       "contents    contents"
       "tags        tags";
 
-    color: inherit;
     text-decoration: none;
 
     & > .heading {

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -101,7 +101,7 @@ const StyledCheckbox = styled.span<{ color?: string }>`
   border-radius: ${({ theme }) => theme.borderRadius.small}px;
   z-index: 1;
 
-  transition: all 100ms;
+  transition: all 150ms;
   ${hoveredStyles}
   ${focusedStyles}
   ${checkedStyles}

--- a/src/components/PageFooter/index.tsx
+++ b/src/components/PageFooter/index.tsx
@@ -35,7 +35,7 @@ const Logo = styled(Icon).attrs({ name: IconName.LOGO })`
   opacity: 0.7;
   width: 30px;
 
-  transition: opacity 100ms ease-out;
+  transition: opacity 150ms ease-out;
   &:hover,
   &:focus {
     opacity: 0.8;

--- a/src/components/PageHeader/index.tsx
+++ b/src/components/PageHeader/index.tsx
@@ -51,7 +51,7 @@ const Container = styled.header`
     background-color: ${({ theme }) => theme.color.backgroundPrimary};
     box-shadow: ${({ theme }) => theme.boxShadow.hover};
 
-    transition: all 100ms ease-in;
+    transition: all 150ms ease-in;
     opacity: 0;
   }
 
@@ -120,7 +120,7 @@ const Logo = styled.div`
       display: inline-block;
       margin-top: 1px;
 
-      transition: transform 100ms ease-in;
+      transition: transform 150ms ease-in;
       &.up {
         transform: rotate(180deg);
       }
@@ -152,7 +152,7 @@ const NavLinks = styled.nav`
     justify-content: flex-start;
     align-items: flex-start;
 
-    transition: all 100ms ease-out;
+    transition: all 150ms ease-out;
     pointer-events: none;
     opacity: 0;
     &.show {
@@ -180,7 +180,7 @@ const HeaderActionContainer = styled.div`
     cursor: pointer;
     margin-left: 10px;
 
-    transition: transform 100ms ease-out;
+    transition: transform 150ms ease-out;
     transform: scale(0.9);
     transform-origin: center;
     &:hover,

--- a/src/components/SearchField/index.tsx
+++ b/src/components/SearchField/index.tsx
@@ -70,7 +70,7 @@ const Container = styled.div`
     border-radius: ${({ theme }) => theme.borderRadius.large}px;
     box-shadow: ${({ theme }) => theme.boxShadow.hover};
 
-    transition: opacity 100ms ease-in;
+    transition: opacity 150ms ease-in;
     opacity: 0;
   }
 
@@ -112,7 +112,7 @@ const Container = styled.div`
   }
 
   & .react-autosuggest__suggestion--highlighted span {
-    transition: color 100ms ease-in;
+    transition: color 150ms ease-in;
     color: ${({ theme }) => theme.color.textPrimary};
   }
 `;

--- a/src/components/SearchOptionsMenu/index.tsx
+++ b/src/components/SearchOptionsMenu/index.tsx
@@ -78,7 +78,7 @@ const Container = styled(Card)<{ menuOpen: boolean }>`
   box-shadow: ${({ theme }) => theme.boxShadow.hover};
 
   z-index: ${({ theme }) => theme.zIndex.header - 1};
-  transition: transform 100ms;
+  transition: transform 150ms;
   transform: ${({ menuOpen }) =>
     menuOpen ? "translateX(0)" : `translateX(${MENU_WIDTH - 65}px)`};
 
@@ -179,7 +179,7 @@ const VerticalAlignContainer = styled.div`
 `;
 
 const CloseIndicator = styled(UnstyledButton)`
-  transition: transform 100ms;
+  transition: transform 150ms;
   transform: scale(0.9);
   cursor: pointer;
 

--- a/src/components/StarRating/index.tsx
+++ b/src/components/StarRating/index.tsx
@@ -56,11 +56,8 @@ const Star = styled.span`
     cursor: not-allowed;
   }
 
-  & > div {
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
-    pointer-events: none;
+  & > svg {
+    transition: color 10ms linear;
   }
 `;
 

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -50,7 +50,7 @@ const Indicator = styled.div<ITooltipProps>`
     display: block;
 
     z-index: 10;
-    animation: fadeIn 100ms ease-in-out;
+    animation: fadeIn 150ms ease-in-out;
     transform-origin: top
       ${({ position }) => (position === "right" ? "left" : "right")};
   }

--- a/src/pages/design-system/page.tsx
+++ b/src/pages/design-system/page.tsx
@@ -24,6 +24,8 @@ import {
   Icon,
   IconName,
 } from "src/components";
+import { useScrollTopOnMount } from "src/shared/hooks/useScrollTopOnMount";
+
 import Section from "./components/Section";
 
 /*******************************************************************
@@ -87,6 +89,8 @@ const PaletteSquare = styled(Card)`
  *                           **Component**                         *
  *******************************************************************/
 const DesignSystemPage = () => {
+  useScrollTopOnMount();
+
   const [numvalue, setNumvalue] = useState(3);
   const [checkboxChecked, setChecked] = useState(false);
 

--- a/src/pages/landing/components/LandingCardDisplay.tsx
+++ b/src/pages/landing/components/LandingCardDisplay.tsx
@@ -121,6 +121,13 @@ const CardsContainer = styled.div`
   align-items: center;
   overflow: scroll;
   -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+
+  &::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
 
   position: relative;
   padding: 25px 0;

--- a/src/pages/reviews/components/AddReviewModal/Contents.tsx
+++ b/src/pages/reviews/components/AddReviewModal/Contents.tsx
@@ -248,7 +248,7 @@ const SubmittedText = styled(Text)`
 
 const ActionButton = styled(Button)`
   min-width: 100px;
-  transition: all 100ms ease;
+  transition: all 150ms ease;
 
   display: flex;
   justify-content: center;

--- a/src/pages/reviews/components/AddReviewModal/index.tsx
+++ b/src/pages/reviews/components/AddReviewModal/index.tsx
@@ -49,7 +49,7 @@ const InnerContainer = styled(Card)`
     0px 0px 0px 2px ${({ theme }) => theme.color.backgroundSecondary};
   overflow-y: scroll;
 
-  transition: all 100ms ease-out;
+  transition: all 150ms ease-out;
   opacity: 0;
   transform: translateY(10px);
   &.open {

--- a/src/pages/reviews/components/ReviewDetailsCard.tsx
+++ b/src/pages/reviews/components/ReviewDetailsCard.tsx
@@ -214,7 +214,7 @@ const CloseButton = styled(UnstyledButton)`
 
   &:hover > .bg,
   &:focus > .bg {
-    transition: transform 100ms ease-out;
+    transition: transform 150ms ease-out;
     transform: scale(1.1);
   }
 

--- a/src/theme/globalStyles.ts
+++ b/src/theme/globalStyles.ts
@@ -20,7 +20,7 @@ const GlobalStyles = createGlobalStyle`
   
   body,
   body * {
-    transition: background-color 200ms ease-in, color 200ms ease-in;
+    transition: background-color 200ms ease-in, color 150ms ease-in;
   }
   
   *, *:before, *:after {

--- a/src/theme/globalStyles.ts
+++ b/src/theme/globalStyles.ts
@@ -2,13 +2,15 @@ import { createGlobalStyle } from "styled-components";
 
 import { SharpSansBold } from "src/assets";
 
-const GlobalStyles = createGlobalStyle`
+export const HeadingFontDefinition = createGlobalStyle`
   @font-face {
     font-family: "Sharp Sans";
     font-weight: bold;
     src: url(${SharpSansBold});
   }
+`;
 
+const GlobalStyles = createGlobalStyle`
   html, body {
     margin: 0;
     padding: 0;

--- a/src/theme/globalStyles.ts
+++ b/src/theme/globalStyles.ts
@@ -6,7 +6,6 @@ const GlobalStyles = createGlobalStyle`
   @font-face {
     font-family: "Sharp Sans";
     font-weight: bold;
-    font-display: swap;
     src: url(${SharpSansBold});
   }
 

--- a/src/theme/snippets.ts
+++ b/src/theme/snippets.ts
@@ -77,7 +77,7 @@ export const inputStyles = css<IInputStyleOptions>`
   cursor: ${({ disabled, readOnly }) =>
     disabled || readOnly ? "not-allowed" : "text"};
 
-  transition: all 100ms;
+  transition: all 150ms;
   border-radius: ${({ theme }) => theme.borderRadius.large}px;
   border: 2px solid transparent;
 

--- a/src/theme/snippets.ts
+++ b/src/theme/snippets.ts
@@ -12,26 +12,11 @@ export const spin = keyframes`
 
 export const hoverStyles = css`
   cursor: pointer;
-  &::after {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    z-index: -1;
-    width: 100%;
-    height: 100%;
+  transition: opacity 200ms;
 
-    border-radius: ${({ theme }) => theme.borderRadius.large}px;
-    box-shadow: ${({ theme }) => theme.boxShadow.hover};
-
-    transition: opacity 100ms ease-in;
-    opacity: 0;
-    backface-visibility: hidden; /* for this issue: https://stackoverflow.com/questions/11045451/white-flash-blink-on-hover-with-chrome */
-  }
-
-  &:hover::after,
-  &:focus::after {
-    opacity: 1;
+  &:hover,
+  &.focus-visible {
+    opacity: 0.7;
   }
 `;
 


### PR DESCRIPTION
### Changes
- Hide landing page scroll bars
- Fixed bug where design-system page wasn't scrolling to top
- Change opacity on Card hovers, not box-shadow
- Transition speed for almost every element is set to 150ms (previously 100ms)
- Add badge for current version to README

### Todo
- [x] Stop fonts from reloading every time dark mode is toggled